### PR TITLE
mruby-mtest should be test_dependency

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -81,5 +81,5 @@ MRuby::Gem::Specification.new('mruby-polarssl') do |spec|
   spec.add_dependency 'mruby-string-ext', :core => 'mruby-string-ext'
   spec.add_dependency 'mruby-io', :mgem => 'mruby-io'
   spec.add_dependency 'mruby-socket', :mgem => 'mruby-socket'
-  spec.add_dependency 'mruby-mtest', :mgem => 'mruby-mtest'
+  spec.add_test_dependency 'mruby-mtest', :mgem => 'mruby-mtest'
 end


### PR DESCRIPTION
cherry-pick from upstream.

When using mruby-acme-client, mruby-mtest is included in release binary becouse of this dependency. But, mruby-mtest should not be included in release binary, and this is fixed in upstream.