### PR TITLE
fix: GCC 14+ でのビルドエラーを修正 (incompatible pointer types)

### DIFF
--- a/src/polarssl.c
+++ b/src/polarssl.c
@@ -454,7 +454,8 @@ static mrb_value mrb_ecdsa_private_key(mrb_state *mrb, mrb_value self) {
 static mrb_value mrb_ecdsa_sign(mrb_state *mrb, mrb_value self) {
   ctr_drbg_context *ctr_drbg;
   unsigned char buf[512], str[1024];
-  int i, j, len=0, ret=0;
+  int ret=0;
+  size_t i, j, len=0;
   ecdsa_context *ecdsa;
   mrb_value hash, obj;
 

--- a/src/polarssl.c
+++ b/src/polarssl.c
@@ -476,7 +476,7 @@ static mrb_value mrb_ecdsa_sign(mrb_state *mrb, mrb_value self) {
   }
 
   if (ret == 0) {
-    return mrb_str_new(mrb, &str, len*2);
+    return mrb_str_new(mrb, (char *)str, len*2);
   } else {
     return mrb_fixnum_value(ret);
   }

--- a/src/polarssl.c
+++ b/src/polarssl.c
@@ -436,10 +436,10 @@ static mrb_value mrb_ecdsa_private_key(mrb_state *mrb, mrb_value self) {
   memset(&str, 0, sizeof(str));
   memset(&buf, 0, sizeof(buf));
 
-  if( ecp_point_write_binary( &ecdsa->grp, &ecdsa->d,
-        POLARSSL_ECP_PF_COMPRESSED, &len, buf, sizeof(buf) ) != 0 )
+  len = mpi_size( &ecdsa->d );
+  if( mpi_write_binary( &ecdsa->d, buf, len ) != 0 )
   {
-    mrb_raise(mrb, E_RUNTIME_ERROR, "can't extract Public Key");
+    mrb_raise(mrb, E_RUNTIME_ERROR, "can't extract Private Key");
     return mrb_false_value();
   }
 
@@ -448,8 +448,7 @@ static mrb_value mrb_ecdsa_private_key(mrb_state *mrb, mrb_value self) {
         "0123456789ABCDEF" [buf[i] % 16] );
   }
 
-  /*return mrb_str_new(mrb, str, len*2);*/
-  return mrb_str_new(mrb, &str[2], len*2 - 2);
+  return mrb_str_new(mrb, (char *)str, len*2);
 }
 
 static mrb_value mrb_ecdsa_sign(mrb_state *mrb, mrb_value self) {


### PR DESCRIPTION
# fix: GCC 14+ でのビルドエラーを修正 (incompatible pointer types)

## 概要

GCC 14 以降、これまで警告だったポインタ型不一致の診断
(`-Wincompatible-pointer-types`) がデフォルトでエラーに昇格しました。このため
GCC 14 以降 (Ubuntu 25.04 / 26.04 など) では `src/polarssl.c` がコンパイルできません。
本 PR はその 3 件のビルドエラーを、1 修正 = 1 コミットで修正します。

## 再現したエラー (GCC 15.2.0 / Ubuntu 26.04)

```
src/polarssl.c:439:44: error: passing argument 2 of 'ecp_point_write_binary' from incompatible pointer type [-Wincompatible-pointer-types]
  note: expected 'const ecp_point *' but argument is of type 'mpi *'
src/polarssl.c:471:12: error: passing argument 5 of 'ecdsa_write_signature' from incompatible pointer type [-Wincompatible-pointer-types]
  note: expected 'size_t *' {aka 'long unsigned int *'} but argument is of type 'int *'
src/polarssl.c:479:29: error: passing argument 2 of 'mrb_str_new' from incompatible pointer type [-Wincompatible-pointer-types]
  note: expected 'const char *' but argument is of type 'unsigned char (*)[1024]'
```

## 修正内容 (コミット単位)

1. **`mrb_ecdsa_private_key`**: 秘密鍵 `d` (`mpi` 型) を、`ecp_point` 型を引数に取る
   `ecp_point_write_binary` に渡していたのが型不一致の原因。`d` を書き出すには
   `mpi_write_binary` が適切なため、そちらに変更。
   - 戻り値も、先頭 1 バイトを除去していた `&str[2], len*2-2` をやめ、全体の hex
     (`str, len*2`) を返す。これにより `test/ecdsa_test.rb` のコメントに記載された
     期待値と一致する (下記「動作確認」)。

2. **`mrb_ecdsa_sign`**: `ecdsa_write_signature` の `slen` 引数は `size_t *` だが、
   `int *` (`&len`) を渡していた。`len` を `size_t` に変更 (ループ変数 `i, j` も併せて
   `size_t` 化し符号比較警告を回避)。

3. **`mrb_ecdsa_sign`**: `mrb_str_new` に配列そのもののアドレス `&str`
   (`unsigned char (*)[1024]`) を渡していた。配列 `str` を `(char *)` で渡すよう修正。

## 動作確認

本 gem を含む mruby 3.3.0 のビルドを Ubuntu 26.04 (GCC 15.2.0) で行い、
`src/polarssl.c` のエラーが解消し、`libmruby.a` の生成と `mruby` バイナリのリンクまで
成功することを確認しました。

実行時の挙動も確認しました。`test/ecdsa_test.rb` の PEM を使い:

```
priv = PolarSSL::PKey::EC.new(pem).private_key
# => "51430268CFC0C8A6D7F543FFB654BF31CF48E6E17C6F41664C2791EEDB8F0520"
```

これは `test/ecdsa_test.rb` のコメントに記載された期待値
(`# @key.private_key.to_int.to_s(16)`)、および openssl で同 PEM から抽出した
秘密鍵 `d` と完全に一致します。`public_key` / `sign` も従来どおり
(公開鍵は期待値一致、署名は hex 文字列) 動作します。

> 修正対象は `mrb_ecdsa_*` 関数のみで、`disable-base64` / `master` の双方で同一です。
> 本 PR は `disable-base64` を対象にしています (このブランチを参照する依存 gem が
> あるため)。同じ差分は `master` にもそのまま適用できます。
